### PR TITLE
Add COS method (Fang & Oosterlee, 2008) for European option pricing

### DIFF
--- a/src/Hedgehog.jl
+++ b/src/Hedgehog.jl
@@ -39,6 +39,7 @@ include("pricing_methods/black_scholes.jl")
 include("pricing_methods/cox_ross_rubinstein.jl")
 include("pricing_methods/montecarlo.jl")
 include("pricing_methods/carr_madan.jl")
+include("pricing_methods/cos_method.jl")
 include("pricing_methods/least_squares_montecarlo.jl")
 
 # sensitivities
@@ -78,6 +79,7 @@ export RectVolSurface, spine_strikes, spine_tenors, spine_vols, get_vol, get_vol
 export PricingProblem, solve
 export BlackScholesAnalytic, implied_vol
 export CarrMadan
+export COSMethod
 export CoxRossRubinsteinMethod
 export MonteCarlo,
     HestonBroadieKaya,

--- a/src/pricing_methods/cos_method.jl
+++ b/src/pricing_methods/cos_method.jl
@@ -1,0 +1,157 @@
+"""
+    COSMethod <: AbstractPricingMethod
+
+Fourier-cosine series expansion pricing method for European options (Fang & Oosterlee, 2008).
+
+Approximates the risk-neutral density via a cosine expansion on a truncated interval,
+then computes option prices as weighted sums of analytically known payoff coefficients.
+Often faster than Carr-Madan for single-strike pricing at comparable accuracy.
+
+# Fields
+- `N`: Number of cosine expansion terms (higher = more accurate, typical: 64–256).
+- `L`: Truncation parameter for the density support in standard deviations (typical: 10–12).
+- `dynamics`: The model dynamics providing the terminal characteristic function.
+
+# References
+- Fang, F. and Oosterlee, C.W. (2008). "A Novel Pricing Method for European Options Based
+  on Fourier-Cosine Series Expansions." SIAM J. Sci. Comput., 31(2), 826–848.
+"""
+struct COSMethod{TN<:Integer, TL<:Real, TDynamics} <: AbstractPricingMethod
+    N::TN
+    L::TL
+    dynamics::TDynamics
+end
+
+"""
+    COSMethod(dynamics; N=128, L=10)
+
+Constructs a `COSMethod` with `N` expansion terms, truncation width `L` standard deviations,
+and the given price dynamics.
+
+# Arguments
+- `dynamics`: The price dynamics (must support `marginal_law`).
+- `N`: Number of cosine terms (default: 128; use 256 for Heston).
+- `L`: Truncation width in standard deviations (default: 10).
+"""
+COSMethod(dynamics; N=128, L=10) = COSMethod(N, L, dynamics)
+
+function solve(
+    prob::PricingProblem{VanillaOption{TS,TE,European,C,Spot},I},
+    method::COSMethod,
+) where {TS,TE,C,I<:AbstractMarketInputs}
+
+    K = prob.payoff.strike
+    r = prob.market_inputs.rate
+    S = prob.market_inputs.spot
+
+    terminal_law = marginal_law(prob, method.dynamics, prob.payoff.expiry)
+    ϕ(u) = cf(terminal_law, u)
+
+    # Determine truncation range [a, b] from cumulants
+    a, b = _cos_truncation_range(ϕ, method.L)
+
+    N = method.N
+    logK = log(K)
+    call_price = _cos_price_call(ϕ, a, b, N, logK, r, prob.payoff.expiry)
+    price = parity_transform(call_price, prob.payoff, S, r)
+
+    return COSSolution(prob, method, price)
+end
+
+"""
+    _cos_truncation_range(ϕ, L)
+
+Determines the truncation range [a, b] for the COS method using cumulants
+estimated from the log-characteristic function via finite differences.
+
+Cumulants are extracted from ln ϕ(u):
+- κ₁ = -i · (d/du) ln ϕ(0)   (mean)
+- κ₂ = -(d²/du²) ln ϕ(0)     (variance)
+- κ₄ = (d⁴/du⁴) ln ϕ(0)      (excess kurtosis contribution)
+"""
+function _cos_truncation_range(ϕ, L)
+    h = 1e-4
+
+    # Evaluate CF at real points for finite differences of ln ϕ(u) w.r.t. u
+    lnϕ0  = log(ϕ(0.0))
+    lnϕp1 = log(ϕ(h))
+    lnϕm1 = log(ϕ(-h))
+    lnϕp2 = log(ϕ(2h))
+    lnϕm2 = log(ϕ(-2h))
+
+    # First cumulant (mean): κ₁ = -i · d/du ln ϕ(0)
+    c1 = real(-im * (lnϕp1 - lnϕm1) / (2h))
+
+    # Second cumulant (variance): κ₂ = -d²/du² ln ϕ(0)
+    c2 = real(-(lnϕp1 - 2lnϕ0 + lnϕm1) / h^2)
+
+    # Fourth cumulant: five-point stencil
+    c4 = abs(real((lnϕp2 - 4lnϕp1 + 6lnϕ0 - 4lnϕm1 + lnϕm2) / h^4))
+
+    # Truncation range (Fang & Oosterlee recommend L ≈ 10–12)
+    width = L * sqrt(abs(c2) + sqrt(c4))
+    a = c1 - width
+    b = c1 + width
+
+    return a, b
+end
+
+"""
+    _cos_price_call(ϕ, a, b, N, logK, rate, expiry)
+
+Computes the European call price using the COS expansion:
+
+    C = e^{-rT} Σ'_{k=0}^{N-1} Re{ ϕ(kπ/(b-a)) · e^{-ikπa/(b-a)} } · V_k
+
+where V_k are analytical payoff coefficients and the prime denotes halving the k=0 term.
+"""
+function _cos_price_call(ϕ, a, b, N, logK, rate, expiry)
+    discount = df(rate, expiry)
+    bma = b - a
+    K = exp(logK)
+
+    price = 0.0
+    for k in 0:(N-1)
+        # CF coefficient: Re{ ϕ(kπ/(b-a)) · exp(-ikπa/(b-a)) }
+        ω = k * π / bma
+        cf_coeff = real(ϕ(ω) * exp(-im * ω * a))
+
+        # Payoff coefficient for call: V_k = (2/(b-a)) * [χ_k(logK, b) - K · ψ_k(logK, b)]
+        Vk = (2.0 / bma) * (_cos_chi(k, logK, b, a, bma) - K * _cos_psi(k, logK, b, a, bma))
+
+        # First term halved (Σ' convention)
+        weight = k == 0 ? 0.5 : 1.0
+        price += weight * cf_coeff * Vk
+    end
+
+    return discount * price
+end
+
+"""
+    _cos_chi(k, c, d, a, bma)
+
+Computes χ_k(c, d) = ∫_c^d e^y cos(kπ(y-a)/(b-a)) dy in closed form.
+"""
+function _cos_chi(k, c, d, a, bma)
+    if k == 0
+        return exp(d) - exp(c)
+    end
+    ω = k * π / bma
+    denom = 1.0 + ω^2
+    term_d = exp(d) * (cos(ω * (d - a)) + ω * sin(ω * (d - a)))
+    term_c = exp(c) * (cos(ω * (c - a)) + ω * sin(ω * (c - a)))
+    return (term_d - term_c) / denom
+end
+
+"""
+    _cos_psi(k, c, d, a, bma)
+
+Computes ψ_k(c, d) = ∫_c^d cos(kπ(y-a)/(b-a)) dy in closed form.
+"""
+function _cos_psi(k, c, d, a, bma)
+    if k == 0
+        return d - c
+    end
+    ω = k * π / bma
+    return (sin(ω * (d - a)) - sin(ω * (c - a))) / ω
+end

--- a/src/solutions/pricing_solutions.jl
+++ b/src/solutions/pricing_solutions.jl
@@ -99,3 +99,19 @@ struct CRRSolution{T <: Number, P<:PricingProblem, M <: AbstractPricingMethod} <
     method::M
     price::T
 end
+
+"""
+    COSSolution{T <: Number, P<:PricingProblem, M <: AbstractPricingMethod} <: AbstractPricingSolution
+
+Represents a pricing solution obtained using the COS (Fourier-cosine expansion) method.
+
+# Fields
+- `problem::P`: The pricing problem definition (`<: PricingProblem`).
+- `method::M`: The specific COS method configuration (`<: AbstractPricingMethod`).
+- `price::T`: The calculated numerical price (`<: Number`).
+"""
+struct COSSolution{T <: Number, P<:PricingProblem, M <: AbstractPricingMethod} <: AbstractPricingSolution
+    problem::P
+    method::M
+    price::T
+end

--- a/test/agreement/price_agreement.jl
+++ b/test/agreement/price_agreement.jl
@@ -25,6 +25,71 @@
         @test isapprox(analytic_sol.price, crr_sol.price; atol = 1e-3)
     end
 
+    @testset "COS method vs Black-Scholes analytical (Call)" begin
+        reference_date = Date(2020, 1, 1)
+        interest_rate = 0.2
+        spot = 100.0
+        sigma = 0.4
+        market_inputs = BlackScholesInputs(reference_date, interest_rate, spot, sigma)
+
+        expiry = reference_date + Day(365)
+        strike = 100.0
+        payoff = VanillaOption(strike, expiry, European(), Call(), Spot())
+        prob = PricingProblem(payoff, market_inputs)
+
+        cos_method = COSMethod(LognormalDynamics(); N=128, L=10)
+        cos_solution = Hedgehog.solve(prob, cos_method)
+
+        bs_solution = Hedgehog.solve(prob, BlackScholesAnalytic())
+
+        @test isapprox(cos_solution.price, bs_solution.price; atol = 1e-6)
+    end
+
+    @testset "COS method vs Black-Scholes analytical (Put)" begin
+        reference_date = Date(2020, 1, 1)
+        interest_rate = 0.05
+        spot = 100.0
+        sigma = 0.3
+        market_inputs = BlackScholesInputs(reference_date, interest_rate, spot, sigma)
+
+        expiry = reference_date + Day(180)
+        strike = 110.0
+        payoff = VanillaOption(strike, expiry, European(), Put(), Spot())
+        prob = PricingProblem(payoff, market_inputs)
+
+        cos_method = COSMethod(LognormalDynamics(); N=128, L=10)
+        cos_solution = Hedgehog.solve(prob, cos_method)
+
+        bs_solution = Hedgehog.solve(prob, BlackScholesAnalytic())
+
+        @test isapprox(cos_solution.price, bs_solution.price; atol = 1e-6)
+    end
+
+    @testset "COS method vs Carr-Madan (Heston)" begin
+        reference_date = Date(2020, 1, 1)
+        rate = 0.05
+        spot = 100.0
+        V0 = 0.04
+        κ = 2.0
+        θ = 0.04
+        σ = 0.3
+        ρ = -0.7
+        market_inputs = HestonInputs(reference_date, rate, spot, V0, κ, θ, σ, ρ)
+
+        expiry = reference_date + Day(365)
+        strike = 100.0
+        payoff = VanillaOption(strike, expiry, European(), Call(), Spot())
+        prob = PricingProblem(payoff, market_inputs)
+
+        cos_method = COSMethod(HestonDynamics(); N=256, L=12)
+        cos_solution = Hedgehog.solve(prob, cos_method)
+
+        carr_madan_method = CarrMadan(1.0, 32, HestonDynamics())
+        carr_madan_solution = Hedgehog.solve(prob, carr_madan_method)
+
+        @test isapprox(cos_solution.price, carr_madan_solution.price; atol = 1e-4)
+    end
+
     @testset "Carr-Madan vs Black-Scholes analytical" begin
         # Define market inputs
         reference_date = Date(2020, 1, 1)


### PR DESCRIPTION
## Summary

Implements the **Fourier-cosine series expansion (COS) method** from Fang & Oosterlee (2008), adding a second Fourier-based pricing method alongside the existing Carr-Madan implementation.

- **New `COSMethod` struct** following the existing `solve(problem, method)` interface — works with both `LognormalDynamics` and `HestonDynamics`
- **Automatic truncation range** via cumulant estimation from the characteristic function (no manual tuning needed)
- **`COSSolution`** result type, consistent with the existing solution hierarchy
- **Three agreement tests**: COS vs BS analytical (call), COS vs BS analytical (put), COS vs Carr-Madan (Heston)

The COS method is often faster than Carr-Madan for single-strike pricing at comparable accuracy, and was explicitly noted as missing in the README comparison with CharFuncPricing.jl.

### Usage

```julia
# Black-Scholes
cos_method = COSMethod(LognormalDynamics(); N=128, L=10)
sol = solve(prob, cos_method)

# Heston (use more terms for stochastic vol)
cos_method = COSMethod(HestonDynamics(); N=256, L=12)
sol = solve(prob, cos_method)
```

## References

Fang, F. and Oosterlee, C.W. (2008). "A Novel Pricing Method for European Options Based on Fourier-Cosine Series Expansions." *SIAM J. Sci. Comput.*, 31(2), 826–848.

## Test plan

- [x] COS vs Black-Scholes analytical agreement (European call, ATM, σ=0.4)
- [x] COS vs Black-Scholes analytical agreement (European put, ITM, σ=0.3)
- [x] COS vs Carr-Madan agreement under Heston dynamics
- [ ] CI passes on Julia 1.10 and 1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)